### PR TITLE
Adding suppressAutoStart to the config object

### DIFF
--- a/src/scripts/service.coffee
+++ b/src/scripts/service.coffee
@@ -28,7 +28,7 @@ angular.module 'ngStopwatch.services'
       if @autoRefresh
         @trackCurrent()
 
-      @start()
+      @start() unless config.suppressAutoStart
 
 
     getTime: ->


### PR DESCRIPTION
I would like to instantiate the timer where I do not want to start it.
```
let timer = stopwatch.create({ suppressAutoStart: true })
```